### PR TITLE
Update ansys-api-geometry dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,6 @@ requires = [
     "setuptools >= 42.0.0", 
     "wheel", 
     "ansys_tools_protoc_helper>=0.4.0", 
-    "ansys-api-geometry==0.4.35"
+    "ansys-api-geometry==0.4.37"
     ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
         url=f"https://github.com/ansys/{package_name}",
         license="MIT",
         python_requires=">=3.10",
-        install_requires=["grpcio~=1.44", "protobuf>=3.19,<6", "ansys-api-geometry==0.4.35"],
+        install_requires=["grpcio~=1.44", "protobuf>=3.19,<6", "ansys-api-geometry==0.4.37"],
         packages=setuptools.find_namespace_packages(".", include=("ansys.*",)),
         package_data={
             "": ["*.proto", "*.pyi", "py.typed", "VERSION"],


### PR DESCRIPTION
Update ansys-api-discovery dependency toward ansys-api-geometry to get PyDiscovery in line with PyAnsys Geometry